### PR TITLE
Add more informative error messages when OS fails to run

### DIFF
--- a/bridge_sim/sim/run/__init__.py
+++ b/bridge_sim/sim/run/__init__.py
@@ -98,7 +98,14 @@ class FEMRunner:
         # Running.
         for sim_ind, _ in enumerate(expt_params):
             start = timer()
-            expt_params = self._run(config, expt_params, self, sim_ind)
+            try:
+                expt_params = self._run(config, expt_params, self, sim_ind)
+            except PermissionError as e:
+                raise PermissionError(
+                    f"{e}\nOn Windows you can try adding the folder containing"
+                    f" the '{self.name}' executable to your $PATH to avoid this"
+                    " error."
+                )
             print_i(
                 f"FEMRunner: ran {self.name}"
                 + f" {sim_ind + 1}/{len(expt_params)}"

--- a/bridge_sim/sim/run/opensees/run.py
+++ b/bridge_sim/sim/run/opensees/run.py
@@ -11,12 +11,19 @@ def run_model(
     c: Config, expt_params: List[SimParams], fem_runner: FEMRunner, sim_ind: int
 ):
     """Run an OpenSees simulation."""
-    subprocess.run(
-        [
-            fem_runner.exe_path,
-            fem_runner.sim_model_path(
-                config=c, sim_params=expt_params[sim_ind], ext="tcl"
-            ),
-        ]
-    )
+    if fem_runner.exe_path:
+        try:
+            subprocess.run(
+                [
+                    fem_runner.exe_path,
+                    fem_runner.sim_model_path(
+                        config=c, sim_params=expt_params[sim_ind], ext="tcl"
+                    ),
+                ]
+            )
+        except PermissionError as e:
+            raise PermissionError(f"{e}\nOn a Windows machine you can try to add the folder"
+                                  f" with `OpenSees.exe` to your $PATH to avoid this error.")
+    else:
+        raise ValueError("No OpenSees exe is found on the $PATH, nor a path (`os_exe`) is provided by the user!")
     return expt_params

--- a/bridge_sim/sim/run/opensees/run.py
+++ b/bridge_sim/sim/run/opensees/run.py
@@ -11,19 +11,12 @@ def run_model(
     c: Config, expt_params: List[SimParams], fem_runner: FEMRunner, sim_ind: int
 ):
     """Run an OpenSees simulation."""
-    if fem_runner.exe_path:
-        try:
-            subprocess.run(
-                [
-                    fem_runner.exe_path,
-                    fem_runner.sim_model_path(
-                        config=c, sim_params=expt_params[sim_ind], ext="tcl"
-                    ),
-                ]
-            )
-        except PermissionError as e:
-            raise PermissionError(f"{e}\nOn a Windows machine you can try to add the folder"
-                                  f" with `OpenSees.exe` to your $PATH to avoid this error.")
-    else:
-        raise ValueError("No OpenSees exe is found on the $PATH, nor a path (`os_exe`) is provided by the user!")
+    subprocess.run(
+        [
+            fem_runner.exe_path,
+            fem_runner.sim_model_path(
+                config=c, sim_params=expt_params[sim_ind], ext="tcl"
+            ),
+        ]
+    )
     return expt_params


### PR DESCRIPTION
## Problems

1. On Windows machines even if the path to OS is provided (`os_exe`), the OS analysis will not run but a permission error is raised.
2. If `fem_runner.exe_path is None` the error message is a bit cryptic:

```
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "C:\Program Files\JetBrains\PyCharm Community Edition 2019.3.3\plugins\python-ce\helpers\pydev\_pydev_bundle\pydev_umd.py", line 197, in runfile
    pydev_imports.execfile(filename, global_vars, local_vars)  # execute the script
  File "C:\Program Files\JetBrains\PyCharm Community Edition 2019.3.3\plugins\python-ce\helpers\pydev\_pydev_imps\_pydev_execfile.py", line 18, in execfile
    exec(compile(contents+"\n", file, 'exec'), glob, loc)
  File "C:/Users/arpada/Working_folder/2020/ERP_DT/bridge-sim/example.py", line 10, in <module>
    responses = sim.responses.load(config, model.RT.YTrans, point_loads)
  File "c:\users\arpada\working_folder\2020\erp_dt\bridge-sim\src\bridge_sim\sim\responses\__init__.py", line 56, in load
    return load_fem_responses(
  File "c:\users\arpada\working_folder\2020\erp_dt\bridge-sim\src\bridge_sim\sim\run\__init__.py", line 252, in load_fem_responses
    c.sim_runner.run(c, [sim_params])
  File "c:\users\arpada\working_folder\2020\erp_dt\bridge-sim\src\bridge_sim\sim\run\__init__.py", line 99, in run
    expt_params = self._run(config, expt_params, self, sim_ind)
  File "c:\users\arpada\working_folder\2020\erp_dt\bridge-sim\src\bridge_sim\sim\run\opensees\run.py", line 17, in run_model
    subprocess.run(
  File "c:\users\arpada\appdata\local\programs\python\python38-32\lib\subprocess.py", line 489, in run
    with Popen(*popenargs, **kwargs) as process:
  File "c:\users\arpada\appdata\local\programs\python\python38-32\lib\subprocess.py", line 854, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "c:\users\arpada\appdata\local\programs\python\python38-32\lib\subprocess.py", line 1247, in _execute_child
    args = list2cmdline(args)
  File "c:\users\arpada\appdata\local\programs\python\python38-32\lib\subprocess.py", line 549, in list2cmdline
    for arg in map(os.fsdecode, seq):
  File "c:\users\arpada\appdata\local\programs\python\python38-32\lib\os.py", line 818, in fsdecode
    filename = fspath(filename)  # Does type-checking of `filename`.
TypeError: expected str, bytes or os.PathLike object, not NoneType
```


## Proposed solution

1. I could make it work on Windows only by adding the path to `os_exe` to `$PATH` -> the permission error is caught and a suggestion to add to `$PATH` is given
2. Raise a specific error: `No OpenSees exe is found on the $PATH, nor a path (os_exe) is provided by the user!`

Tested on Windows 10 and python 3.8.5.